### PR TITLE
- Enabling application insights fix

### DIFF
--- a/backend/appinsightsmiddleware.py
+++ b/backend/appinsightsmiddleware.py
@@ -4,9 +4,9 @@ from applicationinsights.flask.ext import AppInsights
 class AppInsightsMiddleware:
     """Middleware for integrating Application Insights with a Flask application."""
 
-    def __init__(self, app, instrumentation_key = None) -> None:
+    def __init__(self, app, instrumentation_key = os.environ.get('AZURE_APPINSIGHTS_INSTRUMENTATIONKEY', None)) -> None:
         if instrumentation_key and app:
             self.app = app
-            self.instrumentation_key = os.environ.get('AZURE_APPINSIGHTS_INSTRUMENTATIONKEY') or instrumentation_key
+            self.instrumentation_key =  instrumentation_key
             app.config['APPINSIGHTS_INSTRUMENTATIONKEY'] = self.instrumentation_key
             self.appinsights = AppInsights(app)


### PR DESCRIPTION
The `instrumentation_key` attribute is now directly assigned the value of the `instrumentation_key` parameter, instead of first checking for the `AZURE_APPINSIGHTS_INSTRUMENTATIONKEY` environment variable. If the `AZURE_APPINSIGHTS_INSTRUMENTATIONKEY` key does not exist, then `instrumentation_key` defaults to `None`.